### PR TITLE
Feature/delete prediction

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ def delete_prediction(uid: str):
             # Get image paths before deleting from DB
             row = conn.execute("SELECT original_image, predicted_image FROM prediction_sessions WHERE uid = ?", (uid,)).fetchone()
             if not row:
-                raise Exception("Prediction not found")
+                raise HTTPException(status_code=404, detail="Prediction not found")
             original_image, predicted_image = row
 
             # Delete from DB
@@ -185,8 +185,10 @@ def delete_prediction(uid: str):
                 os.remove(path)
 
         return {"detail": "Prediction and images deleted"}
-    except Exception:
-        raise HTTPException(status_code=500, detail="Failed to delete prediction.")
+    except Exception as e:
+        status_code = getattr(e, "status_code", 500)
+        detail = getattr(e, "detail", "Failed to delete prediction.")
+        raise HTTPException(status_code=status_code, detail=detail)
 
 @app.get("/labels")
 def get_labels():

--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ def delete_prediction(uid: str):
             # Get image paths before deleting from DB
             row = conn.execute("SELECT original_image, predicted_image FROM prediction_sessions WHERE uid = ?", (uid,)).fetchone()
             if not row:
-                raise HTTPException(status_code=404, detail="Prediction not found")
+                raise HTTPException(status_code=400, detail="Prediction not found")
             original_image, predicted_image = row
 
             # Delete from DB

--- a/tests/services/image_utils.py
+++ b/tests/services/image_utils.py
@@ -1,0 +1,34 @@
+import io
+from PIL import Image, ImageDraw
+
+def create_dummy_image(color, shape=None):
+    """
+    Creates a dummy image with an optional colored shape for testing purposes.
+
+    Args:
+        color (str or tuple): The color to use for the shape (e.g., 'red', (255, 0, 0)).
+        shape (str, optional): The shape to draw on the image. Supported values are:
+            - 'umbrella': Draws a filled ellipse (umbrella-like shape) in the center.
+            - 'donut': Draws four outlined ellipses (donut-like shapes) in a row.
+            If None or any other value, returns a blank white image.
+
+    Returns:
+        io.BytesIO: A bytes buffer containing the JPEG-encoded image.
+    """
+    test_image = Image.new('RGB', (100, 100), 'white')
+    draw = ImageDraw.Draw(test_image)
+    if shape == 'umbrella':
+        draw.ellipse((25, 25, 75, 75), fill=color, outline='black')
+    elif shape == 'donut':
+        radius = 18
+        spacing = 8
+        y = 50 - radius
+        for i in range(4):
+            x = 8 + i * (radius * 2 + spacing)
+            draw.ellipse((x, y, x + radius * 2, y + radius * 2), outline=color, width=4)
+    
+    # else: just a blank white image
+    image_bytes = io.BytesIO()
+    test_image.save(image_bytes, format='JPEG')
+    image_bytes.seek(0)
+    return image_bytes

--- a/tests/test_delete_prediction.py
+++ b/tests/test_delete_prediction.py
@@ -1,0 +1,85 @@
+import unittest
+import os
+import sqlite3
+from fastapi.testclient import TestClient
+from app import app, DB_PATH, init_db, PREDICTED_DIR, UPLOAD_DIR
+from tests.services.image_utils import create_dummy_image
+
+class TestDeletePredictionEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        # Clean DB and folders for isolation
+        if os.path.exists(DB_PATH):
+            os.remove(DB_PATH)
+        init_db()
+        # remove any existing files in upload and predicted directories
+        for dir in [UPLOAD_DIR, PREDICTED_DIR]:
+            if os.path.exists(dir):
+                for file in os.listdir(dir):
+                    os.remove(os.path.join(dir, file))
+
+    def test_delete_existing_prediction(self):
+        # Arrange
+        image = create_dummy_image('red','donut')
+        response = self.client.post(
+            "/predict",
+            files={"file": ("test_image.jpg", image, "image/jpeg")}
+        )
+        prediction = response.json()
+        uid = prediction['prediction_uid']
+        
+        # Act
+        prediction_delete_response = self.client.delete(f"/prediction/{uid}")
+
+        # Assert
+        expected_response = {"detail": "Prediction and images deleted"}
+        self.assertEqual(prediction_delete_response.status_code, 200)
+        self.assertEqual(prediction_delete_response.json(), expected_response)
+
+    # def test_delete_nonexistent_prediction(self):
+    #     uid = "does-not-exist-uid"
+    #     resp = self.client.delete(f"/prediction/{uid}")
+    #     self.assertIn(resp.status_code, (400, 404))
+    #     self.assertIn("not found", resp.json()["detail"].lower())
+
+    # def test_delete_twice_returns_404(self):
+    #     uid, orig_path, pred_path = self.create_dummy_prediction()
+    #     resp1 = self.client.delete(f"/prediction/{uid}")
+    #     self.assertEqual(resp1.status_code, 200)
+    #     resp2 = self.client.delete(f"/prediction/{uid}")
+    #     self.assertIn(resp2.status_code, (400, 404))
+
+    # def test_delete_prediction_file_removal_failure(self):
+    #     uid, orig_path, pred_path = self.create_dummy_prediction()
+    #     # Patch os.remove to raise OSError
+    #     original_remove = os.remove
+    #     def fail_remove(path):
+    #         raise OSError("Simulated file removal error")
+    #     os.remove = fail_remove
+    #     try:
+    #         resp = self.client.delete(f"/prediction/{uid}")
+    #         self.assertEqual(resp.status_code, 500)
+    #         self.assertIn("failed to delete", resp.json()["detail"].lower())
+    #     finally:
+    #         os.remove = original_remove
+    #         # Clean up files if still exist
+    #         for p in [orig_path, pred_path]:
+    #             if os.path.exists(p):
+    #                 os.remove(p)
+
+    # def test_delete_prediction_missing_files(self):
+    #     # Only create DB entry, no files
+    #     uid, orig_path, pred_path = self.create_dummy_prediction(missing_files=['original', 'predicted'])
+    #     self.assertFalse(os.path.exists(orig_path))
+    #     self.assertFalse(os.path.exists(pred_path))
+    #     resp = self.client.delete(f"/prediction/{uid}")
+    #     self.assertEqual(resp.status_code, 200)
+    #     self.assertIn("deleted", resp.json()["detail"].lower())
+    #     # DB should be gone
+    #     with sqlite3.connect(DB_PATH) as conn:
+    #         row = conn.execute("SELECT * FROM prediction_sessions WHERE uid = ?", (uid,)).fetchone()
+    #         self.assertIsNone(row)
+
+
+
+

--- a/tests/test_delete_prediction.py
+++ b/tests/test_delete_prediction.py
@@ -36,50 +36,43 @@ class TestDeletePredictionEndpoint(unittest.TestCase):
         self.assertEqual(prediction_delete_response.status_code, 200)
         self.assertEqual(prediction_delete_response.json(), expected_response)
 
-    # def test_delete_nonexistent_prediction(self):
-    #     uid = "does-not-exist-uid"
-    #     resp = self.client.delete(f"/prediction/{uid}")
-    #     self.assertIn(resp.status_code, (400, 404))
-    #     self.assertIn("not found", resp.json()["detail"].lower())
+    def test_delete_none_existent_prediction(self):
+        # Arrange
+        uid = "does-not-exist-uid"
+        
+        # Act
+        resp = self.client.delete(f"/prediction/{uid}")
+        
+        # Assert
+        expected_response = {"detail": "Prediction not found"}
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), expected_response)
 
-    # def test_delete_twice_returns_404(self):
-    #     uid, orig_path, pred_path = self.create_dummy_prediction()
-    #     resp1 = self.client.delete(f"/prediction/{uid}")
-    #     self.assertEqual(resp1.status_code, 200)
-    #     resp2 = self.client.delete(f"/prediction/{uid}")
-    #     self.assertIn(resp2.status_code, (400, 404))
-
-    # def test_delete_prediction_file_removal_failure(self):
-    #     uid, orig_path, pred_path = self.create_dummy_prediction()
-    #     # Patch os.remove to raise OSError
-    #     original_remove = os.remove
-    #     def fail_remove(path):
-    #         raise OSError("Simulated file removal error")
-    #     os.remove = fail_remove
-    #     try:
-    #         resp = self.client.delete(f"/prediction/{uid}")
-    #         self.assertEqual(resp.status_code, 500)
-    #         self.assertIn("failed to delete", resp.json()["detail"].lower())
-    #     finally:
-    #         os.remove = original_remove
-    #         # Clean up files if still exist
-    #         for p in [orig_path, pred_path]:
-    #             if os.path.exists(p):
-    #                 os.remove(p)
-
-    # def test_delete_prediction_missing_files(self):
-    #     # Only create DB entry, no files
-    #     uid, orig_path, pred_path = self.create_dummy_prediction(missing_files=['original', 'predicted'])
-    #     self.assertFalse(os.path.exists(orig_path))
-    #     self.assertFalse(os.path.exists(pred_path))
-    #     resp = self.client.delete(f"/prediction/{uid}")
-    #     self.assertEqual(resp.status_code, 200)
-    #     self.assertIn("deleted", resp.json()["detail"].lower())
-    #     # DB should be gone
-    #     with sqlite3.connect(DB_PATH) as conn:
-    #         row = conn.execute("SELECT * FROM prediction_sessions WHERE uid = ?", (uid,)).fetchone()
-    #         self.assertIsNone(row)
-
-
+    def test_delete_twice_returns_400(self):
+        # Arrange
+        image = create_dummy_image('red','donut')
+        response = self.client.post(
+            "/predict",
+            files={"file": ("test_image.jpg", image, "image/jpeg")}
+        )
+        prediction = response.json()
+        uid = prediction['prediction_uid']
+        
+        # Act - first delete
+        first_delete_response = self.client.delete(f"/prediction/{uid}")
+        
+        # Assert first delete
+        expected_first_response = {"detail": "Prediction and images deleted"}
+        self.assertEqual(first_delete_response.status_code, 200)
+        self.assertEqual(first_delete_response.json(), expected_first_response)
+        
+        # Act - second delete
+        second_delete_response = self.client.delete(f"/prediction/{uid}")
+        
+        # Assert second delete
+        expected_second_response = {"detail": "Prediction not found"}
+        self.assertEqual(second_delete_response.status_code, 400)
+        self.assertEqual(second_delete_response.json(), expected_second_response)
+        
 
 


### PR DESCRIPTION
This pull request introduces a new feature to delete prediction sessions by `uid`, along with supporting utilities and tests. The changes include adding an API endpoint, creating a utility for generating test images, and implementing comprehensive tests for the new functionality.

### New Feature: Delete Prediction by `uid`

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R165-R192): Added a new `DELETE /prediction/{uid}` endpoint to delete prediction sessions and associated images from the database and filesystem. Includes error handling for non-existent predictions.

### Utilities for Testing

* [`tests/services/image_utils.py`](diffhunk://#diff-62b8cc2719e3c29066336ec315086c97b6cbb42047c083aeab541a49cd7d5d60R1-R34): Added a `create_dummy_image` function to generate dummy images with optional shapes (e.g., "umbrella" or "donut") for testing purposes.

### Comprehensive Tests for the New Endpoint

* [`tests/test_delete_prediction.py`](diffhunk://#diff-ca3587a2773f315815ddc4ac200952e2b1b19d660a1a1e9290de00efdb1a723eR1-R78): Added unit tests for the `DELETE /prediction/{uid}` endpoint, covering scenarios such as deleting an existing prediction, attempting to delete a non-existent prediction, and verifying behavior when deleting the same prediction twice.