### PR TITLE
fix: correct service name in systemctl status command

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,4 +55,4 @@ jobs:
             else
               sudo systemctl start yolo
             fi
-            sudo systemctl status yoloservice --no-pager
+            sudo systemctl status yolo --no-pager


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yaml` file. The change updates the service name in the `sudo systemctl status` command to match the correct service name, `yolo`.