### PR TITLE
fix: correct import statement for PredictionSession in predictions.py…

### DIFF
--- a/db/dao/predictions.py
+++ b/db/dao/predictions.py
@@ -1,4 +1,4 @@
-from models.predection_session import PredictionSession
+from models.prediction_session import PredictionSession
 from models.detection_object import DetectionObject
 
 def save_prediction_session_dao(db,uid, original_image, predicted_image, user_id):

--- a/db/utils.py
+++ b/db/utils.py
@@ -1,7 +1,7 @@
 from db.setup_db import SessionLocal, Base, engine
 # Dont remove models imports, it is necessary for the models to be registered
 import models.detection_object
-import models.predection_session
+import models.prediction_session
 import models.user
 # END of models imports
 

--- a/models/prediction_session.py
+++ b/models/prediction_session.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy import Column, String, DateTime, ForeignKey, Integer
 from datetime import datetime
 # All models inherit from this base class
 from db.setup_db import Base
@@ -12,7 +12,7 @@ class PredictionSession(Base):
     __tablename__ = 'prediction_sessions'
     
     uid = Column(String, primary_key=True)
-    user_id = Column(String, ForeignKey('users.id'), nullable=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
     original_image = Column(String)
     predicted_image = Column(String)

--- a/tests/test_detection_object_dao.py
+++ b/tests/test_detection_object_dao.py
@@ -1,0 +1,27 @@
+import unittest
+from db.utils import init_db, get_db
+from models.detection_object import DetectionObject
+from db.dao.detections import save_detection_object_dao
+
+class TestDetectionObjectDAO(unittest.TestCase):
+    def setUp(self):
+        # Use in-memory SQLite for isolation
+        init_db()
+        self.db = get_db().__next__()
+
+    def tearDown(self): 
+        self.db.close()
+
+    def test_save_detection_object_dao(self):
+        prediction_uid = 'test-uid'
+        label = 'cat'
+        score = 0.95
+        box = [1, 2, 3, 4]
+        save_detection_object_dao(self.db, prediction_uid, label, score, box)
+        obj = self.db.query(DetectionObject).filter_by(prediction_uid=prediction_uid).first()
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.label, label)
+        self.assertEqual(obj.score, score)
+        self.assertEqual(obj.box, str(box))
+
+    

--- a/tests/test_prediction_dao.py
+++ b/tests/test_prediction_dao.py
@@ -1,0 +1,108 @@
+import unittest
+from db.utils import init_db, get_db
+from models.detection_object import DetectionObject
+from db.dao.predictions import (save_prediction_session_dao, 
+                                get_predictions_count_dao, 
+                                get_prediction_by_uid_dao, 
+                                delete_prediction_by_uid_dao,
+                                get_all_predictions_by_label_dao,
+                                get_all_predictions_by_score_dao)
+from db.dao.detections import save_detection_object_dao
+from models.prediction_session import PredictionSession  # Import PredictionSession
+
+class TestPredictionDAO(unittest.TestCase):
+    def setUp(self):
+        # Use in-memory SQLite for isolation
+        init_db()
+        self.db = get_db().__next__()
+        self.p = PredictionSession(
+            uid='test-uid',
+            original_image='original_image.jpg',
+            predicted_image='predicted_image.jpg',
+            user_id=1
+        )
+
+    def tearDown(self): 
+        self.db.close()
+
+    def test_save_detection_object_dao(self):
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        obj = self.db.query(PredictionSession).filter_by(uid=self.p.uid).first()
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.uid, self.p.uid)
+        self.assertEqual(obj.original_image, self.p.original_image)
+        self.assertEqual(obj.predicted_image, self.p.predicted_image)
+        self.assertEqual(obj.user_id, self.p.user_id)
+    
+    def test_get_predictions_count_dao(self):
+        # Add a prediction session to the database
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        
+        # Test count without timestamp
+        count = get_predictions_count_dao(self.db)
+        self.assertEqual(count, 1)
+        
+        # Test count with timestamp
+        count_since = get_predictions_count_dao(self.db, timestamp='2023-01-01')
+        self.assertEqual(count_since, 1)
+    
+    def test_get_prediction_by_uid_dao(self):
+        # Add a prediction session to the database
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        
+        # Retrieve by UID
+        retrieved = get_prediction_by_uid_dao(self.db, self.p.uid)
+        self.assertIsNotNone(retrieved)
+        self.assertEqual(retrieved.uid, self.p.uid)
+    
+    def test_delete_prediction_by_uid_dao(self):
+        # Add a prediction session to the database
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        
+        # Delete by UID
+        delete_prediction_by_uid_dao(self.db, self.p.uid)
+        
+        # Verify deletion
+        deleted = get_prediction_by_uid_dao(self.db, self.p.uid)
+        self.assertIsNone(deleted)
+        
+    def test_get_all_predictions_by_label_dao(self):
+        # Add a prediction session with a detection object
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        detection_obj = DetectionObject(
+            prediction_uid=self.p.uid,
+            label='cat',
+            score=0.95,
+            box=[1, 2, 3, 4]
+        )
+        save_detection_object_dao(self.db,
+                                  detection_obj.prediction_uid,
+                                  detection_obj.label,
+                                  detection_obj.score,
+                                  detection_obj.box)
+        
+        # Retrieve predictions by label
+        predictions = get_all_predictions_by_label_dao(self.db, 'cat')
+        self.assertGreater(len(predictions), 0)
+        self.assertEqual(predictions[0].uid, self.p.uid)
+        
+    
+    def test_get_all_predictions_by_score_dao(self):
+        # Add a prediction session with a detection object
+        save_prediction_session_dao(self.db, self.p.uid, self.p.original_image, self.p.predicted_image, self.p.user_id)
+        detection_obj = DetectionObject(
+            prediction_uid=self.p.uid,
+            label='dog',
+            score=0.85,
+            box=[5, 6, 7, 8]
+        )
+        save_detection_object_dao(self.db,
+                                  detection_obj.prediction_uid,
+                                  detection_obj.label,
+                                  detection_obj.score,
+                                  detection_obj.box)
+        
+        # Retrieve predictions by score
+        predictions = get_all_predictions_by_score_dao(self.db, 0.8)
+        self.assertGreater(len(predictions), 0)
+        self.assertEqual(predictions[0].uid, self.p.uid)


### PR DESCRIPTION
This pull request involves several changes to improve the database models, fix naming inconsistencies, and add comprehensive unit tests for DAO methods. The most important changes include renaming and updating the `PredictionSession` model, fixing import statements, and adding new unit tests for DAO methods.

### Database Model Updates:
* `models/predection_session.py` renamed to `models/prediction_session.py` to fix a typo in the file name.
* Updated the `user_id` column in `PredictionSession` to use the `Integer` type instead of `String` for better alignment with foreign key constraints.

### Import Fixes:
* Fixed import statements in `db/dao/predictions.py` and `db/utils.py` to use the corrected `models.prediction_session` module name. [[1]](diffhunk://#diff-b0797741e0032a63d157f14b98ca97e905871964cf4061545c5c7af5652c342dL1-R1) [[2]](diffhunk://#diff-bbb15d17dcec387334a2b1307a77f64146b6012a2050e75450da8fe074c47462L4-R4)

### Unit Tests for DAO Methods:
* Added `tests/test_detection_object_dao.py` with unit tests for `save_detection_object_dao` to validate detection object persistence.
* Added `tests/test_prediction_dao.py` with unit tests for multiple DAO methods, including saving, retrieving, deleting, and filtering prediction sessions by label and score.… and utils.py

