### PR TITLE
fix: update DATABASE_URL for PostgreSQL and add psycopg2 to requirements

### DIFF
--- a/db/setup_db.py
+++ b/db/setup_db.py
@@ -7,8 +7,10 @@ DB_BACKEND = os.getenv("DB_BACKEND", "sqlite")
 Base = declarative_base()
 
 if DB_BACKEND == "postgres":
-    DATABASE_URL = "postgresql://user:pass@localhost/db"
+    print("Using PostgreSQL as the database backend.")
+    DATABASE_URL = "postgresql://user:pass@127.0.0.1/predictions"
 else:
+    print("Using SQLite as the database backend.")
     DATABASE_URL = "sqlite:///./predictions.db"
 
 engine = create_engine(

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-html==3.2.0
 
 sqlalchemy
+psycopg2


### PR DESCRIPTION
This pull request modifies the database setup logic in `db/setup_db.py` to improve clarity and update connection details.

### Changes to database setup:

* Added print statements to indicate the database backend being used (`PostgreSQL` or `SQLite`) for better transparency during setup.
* Updated the PostgreSQL connection string to use `127.0.0.1` instead of `localhost` and changed the database name to `predictions`.