### PR TITLE
feat: refactor S3 image handling in prediction service and update tests

### DIFF
--- a/tests/test_prediction_time.py
+++ b/tests/test_prediction_time.py
@@ -27,8 +27,7 @@ class TestProcessingTime(unittest.TestCase):
             "time_took": 123.456  # Mocked processing time
         }
         response = self.client.post(
-            "/predict",
-            files={"file": ("test_image.jpg", io.BytesIO(b"fake image data"), "image/jpeg")}
+            "/predict?img_name=bear.jpg&chat_id=79f3d334-e294-4d9e-8a29-f6fa7c558877",
         )
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -39,7 +38,8 @@ class TestProcessingTime(unittest.TestCase):
         self.assertIsInstance(data["time_took"], (int, float))
         self.assertGreater(data["time_took"], 0)
         mock_create_prediction.assert_called_once_with(
-            ANY,  # The file object
+            ANY,  # The chat_id string
+            ANY,  # The img_name string
             ANY,  # The request object
             ANY   # The database session
         )
@@ -53,8 +53,7 @@ class TestProcessingTime(unittest.TestCase):
         # Act
         # Send invalid file (not an image)
         response = self.client.post(
-            "/predict",
-            files={"file": ("test.txt", io.BytesIO(b"not an image"), "text/plain")}
+            "/predict?img_name=bear.jpg&chat_id=79f3d334-e294-4d9e-8a29-f6fa7c558877",
         )
         
         # Assert


### PR DESCRIPTION
This pull request refactors S3 file handling in the prediction service by extracting upload and download logic into helper functions, and updates the test suite to mock these new helpers. It also standardizes how image paths and prediction endpoints are called in tests, improving reliability and maintainability.

**S3 File Handling Refactor:**
- Extracted S3 download and upload logic into new helper functions `download_from_s3` and `upload_to_s3` in `services/prediction_service.py`, replacing inline S3 operations and centralizing error handling. [[1]](diffhunk://#diff-cb035f799195355e1aef4e780aeaffbaabe7662f9e40b95cc83be4f507e51d91L28-R34) [[2]](diffhunk://#diff-cb035f799195355e1aef4e780aeaffbaabe7662f9e40b95cc83be4f507e51d91L50-R44) [[3]](diffhunk://#diff-cb035f799195355e1aef4e780aeaffbaabe7662f9e40b95cc83be4f507e51d91R188-R206)

**Test Suite Updates:**
- Updated tests in `tests/test_auth_middleware.py` and `tests/test_prediction_time.py` to patch the new S3 helper functions, ensuring tests do not perform real S3 operations.
- Changed test prediction endpoint calls to use query parameters (`img_name` and `chat_id`) instead of file uploads, aligning with the updated API contract. [[1]](diffhunk://#diff-905236a0b701c40dc4208ff58a489a0b8fec83e18ad6ffe80ed7811b3b446c2aL41-R62) [[2]](diffhunk://#diff-8b5772c1c807b6b84045e71c317f61a1fb56b18a951fe3fa6cbe29ab20a27a41L30-R30) [[3]](diffhunk://#diff-8b5772c1c807b6b84045e71c317f61a1fb56b18a951fe3fa6cbe29ab20a27a41L56-R56)
- Adjusted test mocks to match the new function signatures in the prediction service, ensuring correct parameter passing and improved test reliability.

**Test Infrastructure Improvements:**
- Added necessary imports (`os`, `numpy`, `PIL.Image`) and utilities in test files to support new test logic and image handling.